### PR TITLE
Secure Skitch / Slight Refactor

### DIFF
--- a/Skitch/Skitch.download.recipe
+++ b/Skitch/Skitch.download.recipe
@@ -12,7 +12,7 @@
         <string>Skitch</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.6.0</string>
     <key>Process</key>
     <array>
         <dict>
@@ -21,7 +21,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://evernote.com/download/get.php?file=SkitchMac</string>
+                <string>https://evernote.com/download/get.php?file=SkitchMac</string>
                 <key>filename</key>
                 <string>Skitch.zip</string>
             </dict>
@@ -29,6 +29,30 @@
         <dict>
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>Unarchiver</string>
+            <key>Arguments</key>
+            <dict>
+                <key>archive_path</key>
+                <string>%pathname%</string>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Skitch.app</string>
+                <key>requirement</key>
+                <string>identifier "com.skitch.skitch" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "J8RPQ294UB"</string>
+            </dict>
         </dict>
     </array>
 </dict>

--- a/Skitch/Skitch.munki.recipe
+++ b/Skitch/Skitch.munki.recipe
@@ -29,24 +29,11 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.6.0</string>
     <key>ParentRecipe</key>
     <string>com.github.sheagcraig.download.Skitch</string>
     <key>Process</key>
     <array>
-        <dict>
-            <key>Processor</key>
-            <string>Unarchiver</string>
-            <key>Arguments</key>
-            <dict>
-                <key>archive_path</key>
-                <string>%pathname%</string>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
-                <key>purge_destination</key>
-                <true/>
-            </dict>
-        </dict>
         <dict>
             <key>Processor</key>
             <string>DmgCreator</string>

--- a/Skitch/Skitch.pkg.recipe
+++ b/Skitch/Skitch.pkg.recipe
@@ -3,8 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest version of Skitch and makes a pkg of it
-</string>
+    <string>Downloads the latest version of Skitch and makes a pkg of it</string>
     <key>Identifier</key>
     <string>com.github.sheagcraig.pkg.Skitch</string>
     <key>Input</key>
@@ -15,7 +14,7 @@
         <string>com.skitch.skitch</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.5</string>
+    <string>0.6.0</string>
     <key>ParentRecipe</key>
     <string>com.github.sheagcraig.download.Skitch</string>
     <key>Process</key>
@@ -49,20 +48,11 @@
         </dict>
         <dict>
             <key>Processor</key>
-            <string>PlistReader</string>
+            <string>Versioner</string>
             <key>Arguments</key>
             <dict>
-                <key>info_path</key>
-                <string>%pkgroot%/Applications/Skitch.app</string>
-                <key>plist_keys</key>
-                <dict>
-                    <key>CFBundleShortVersionString</key>
-                    <string>version</string>
-                    <key>CFBundleIdentifier</key>
-                    <string>bundleid</string>
-                    <key>CFBundleName</key>
-                    <string>app_name</string>
-                </dict>
+                <key>input_plist_path</key>
+                <string>%pkgroot%/Applications/Skitch.app/Contents/Info.plist</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Skitch now uses a https URL and CodeSignatureVerifier. Child recipes refactored to work with new parent.