### PR TITLE
Code sig ver note for Jin

### DIFF
--- a/Jin/Jin.download.recipe
+++ b/Jin/Jin.download.recipe
@@ -3,7 +3,9 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of Jin</string>
+    <string>Downloads the current release version of Jin
+    Note: Code signature verification for Jin probably cannot be done at this time. It doesn't appear to be using version 2
+    or even version 1: Sealed Resources=none</string>
     <key>Identifier</key>
     <string>com.github.sheagcraig.download.Jin</string>
     <key>Input</key>


### PR DESCRIPTION
Just made a note that code signature verification probably won't work for Jin's download recipe. Haven't actually tested it, but this is the output to go on:
```
codesign --display -r- --deep -v /Applications/Jin.app 
Executable=/Applications/Jin.app/Contents/MacOS/JavaApplicationStub
Identifier=com.apple.JavaApplicationStub
Format=app bundle with Mach-O universal (i386 x86_64)
CodeDirectory v=20100 size=178 flags=0x0(none) hashes=3+2 location=embedded
Signature size=4097
Info.plist=not bound
TeamIdentifier=not set
Sealed Resources=none
designated => identifier "com.apple.JavaApplicationStub" and anchor apple
```
JavaApplicationStub doesn't sound too promising, nor does there being no Sealed Resources.