### PR TITLE
SketchUpMake 2016 -> 2017

### DIFF
--- a/Sketchup/SketchUpMake.munki.recipe
+++ b/Sketchup/SketchUpMake.munki.recipe
@@ -54,7 +54,7 @@
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>%pathname%/SketchUp 2016/SketchUp.app</string>
+                <string>%pathname%/SketchUp 2017/SketchUp.app</string>
                 <key>destination_path</key>
                 <string>%pkgroot%/Applications/SketchUp.app</string>
             </dict>


### PR DESCRIPTION
Overnight our  autopkg run building SketchUpMake failed with the error:

    Error in local.munki.SketchUpMake: Processor: Copier: Error: Error processing path '/private/tmp/dmg.3oJsL1/SketchUp 2016/SketchUp.app' with glob.

Checking the downloaded DMG showes that the path had changed to be
"SketchUp 2017" rathat than "SketchUp 2016":

$ hdiutil attach -mountrandom /private/tmp -nobrowse SketchUpMake-en.dmg
<snip>
stelmaria:~ autopkg$ ls -ld /private/tmp/dmg.MRVnkG/*
-r-xr-xr-x@ 1 autopkg  staff  113324  1 Nov 20:20 /private/tmp/dmg.MRVnkG/Applications
drwxr-xr-x@ 6 autopkg  staff     204  1 Nov 20:20 /private/tmp/dmg.MRVnkG/SketchUp 2017

so, I've updated the recipe to reflect this change.

Re-running autopkg runs as expected.