### PR TITLE
tar.gz to dmg switch URLTextSearcher url

### DIFF
--- a/Eclipse/Eclipse.download.recipe
+++ b/Eclipse/Eclipse.download.recipe
@@ -27,31 +27,31 @@
                 <key>options</key>
                 <dict>
                     <key>Eclipse IDE for Java EE Developers</key>
-                    <string>href="\/downloads\/download\.php\?file=([/\w]+eclipse-jee[\w-]+macosx-cocoa-x86_64\.tar\.gz)"</string>
+                    <string>href="\/downloads\/download\.php\?file=([/\w]+eclipse-jee[\w-]+macosx-cocoa-x86_64\.dmg)"</string>
                     <key>Eclipse IDE for Java Developers</key>
-                    <string>href="\/downloads\/download\.php\?file=([/\w]+eclipse-java[\w-]+macosx-cocoa-x86_64\.tar\.gz)"</string>
+                    <string>href="\/downloads\/download\.php\?file=([/\w]+eclipse-java[\w-]+macosx-cocoa-x86_64\.dmg)"</string>
                     <key>Eclipse IDE for C/C++ Developers</key>
-                    <string>href="\/downloads\/download\.php\?file=([/\w]+eclipse-cpp[\w-]+macosx-cocoa-x86_64\.tar\.gz)"</string>
+                    <string>href="\/downloads\/download\.php\?file=([/\w]+eclipse-cpp[\w-]+macosx-cocoa-x86_64\.dmg)"</string>
                     <key>Eclipse IDE for Eclipse Committers</key>
-                    <string>href="\/downloads\/download\.php\?file=([/\w]+eclipse-committers[\w-]+macosx-cocoa-x86_64\.tar\.gz)"</string>
+                    <string>href="\/downloads\/download\.php\?file=([/\w]+eclipse-committers[\w-]+macosx-cocoa-x86_64\.dmg)"</string>
                     <key>Eclipse for PHP Developers</key>
-                    <string>href="\/downloads\/download\.php\?file=([/\w]+eclipse-php[\w-]+macosx-cocoa-x86_64\.tar\.gz)"</string>
+                    <string>href="\/downloads\/download\.php\?file=([/\w]+eclipse-php[\w-]+macosx-cocoa-x86_64\.dmg)"</string>
                     <key>Eclipse IDE for Java and DSL Developers</key>
-                    <string>href="\/downloads\/download\.php\?file=([/\w]+eclipse-dsl[\w-]+macosx-cocoa-x86_64\.tar\.gz)"</string>
+                    <string>href="\/downloads\/download\.php\?file=([/\w]+eclipse-dsl[\w-]+macosx-cocoa-x86_64\.dmg)"</string>
                     <key>Eclipse for RCP and RAP Developers</key>
-                    <string>href="\/downloads\/download\.php\?file=([/\w]+eclipse-rcp[\w-]+macosx-cocoa-x86_64\.tar\.gz)"</string>
+                    <string>href="\/downloads\/download\.php\?file=([/\w]+eclipse-rcp[\w-]+macosx-cocoa-x86_64\.dmg)"</string>
                     <key>Eclipse IDE for Automotive Software Developers</key>
-                    <string>href="\/downloads\/download\.php\?file=([/\w]+eclipse-automotive[\w-]+macosx-cocoa-x86_64\.tar\.gz)"</string>
+                    <string>href="\/downloads\/download\.php\?file=([/\w]+eclipse-automotive[\w-]+macosx-cocoa-x86_64\.dmg)"</string>
                     <key>Eclipse Modeling Tools</key>
-                    <string>href="\/downloads\/download\.php\?file=([/\w]+eclipse-modeling[\w-]+macosx-cocoa-x86_64\.tar\.gz)"</string>
+                    <string>href="\/downloads\/download\.php\?file=([/\w]+eclipse-modeling[\w-]+macosx-cocoa-x86_64\.dmg)"</string>
                     <key>Eclipse IDE for Java and Report Developers</key>
-                    <string>href="\/downloads\/download\.php\?file=([/\w]+eclipse-reporting[\w-]+macosx-cocoa-x86_64\.tar\.gz)"</string>
+                    <string>href="\/downloads\/download\.php\?file=([/\w]+eclipse-reporting[\w-]+macosx-cocoa-x86_64\.dmg)"</string>
                     <key>Eclipse for Parallel Application Developers</key>
-                    <string>href="\/downloads\/download\.php\?file=([/\w]+eclipse-parallel[\w-]+macosx-cocoa-x86_64\.tar\.gz)"</string>
+                    <string>href="\/downloads\/download\.php\?file=([/\w]+eclipse-parallel[\w-]+macosx-cocoa-x86_64\.dmg)"</string>
                     <key>Eclipse for Testers</key> 
-                    <string>href="\/downloads\/download\.php\?file=([/\w]+eclipse-testing[\w-]+macosx-cocoa-x86_64\.tar\.gz)"</string>
+                    <string>href="\/downloads\/download\.php\?file=([/\w]+eclipse-testing[\w-]+macosx-cocoa-x86_64\.dmg)"</string>
                     <key>Eclipse for Scout Developers</key>
-                    <string>href="\/downloads\/download\.php\?file=([/\w]+eclipse-scout[\w-]+macosx-cocoa-x86_64\.tar\.gz)"</string>
+                    <string>href="\/downloads\/download\.php\?file=([/\w]+eclipse-scout[\w-]+macosx-cocoa-x86_64\.dmg)"</string>
                 </dict>
             </dict>
         </dict>


### PR DESCRIPTION
tar.gz to dmg switch on https://eclipse.org/downloads/eclipse-packages/