### PR TITLE
Update to VirtualBox.download.recipe

### DIFF
--- a/VirtualBox/VirtualBox.download.recipe
+++ b/VirtualBox/VirtualBox.download.recipe
@@ -23,9 +23,9 @@
                 <key>url</key>
                 <string>https://www.virtualbox.org/wiki/Downloads</string>
                 <key>re_pattern</key>
-                <string>http://download\.virtualbox\.org/virtualbox/[0-9\.]*/VirtualBox-[0-9\.-]*-OSX.dmg</string>
+                <string>https?://download\.virtualbox\.org/virtualbox/[0-9\.]*/VirtualBox-[0-9\.-]*-OSX.dmg</string>
                 <key>comment</key>
-                <string>Example: http://download.virtualbox.org/virtualbox/4.3.10/VirtualBox-4.3.10-93012-OSX.dmg</string>
+                <string>Example: https://download.virtualbox.org/virtualbox/4.3.10/VirtualBox-4.3.10-93012-OSX.dmg</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
VirtualBox updated their wiki to use a https link instead of an http one, therefore causing the url searcher to not find a download link. Added the option for them to use either a http or https address.