### PR TITLE
Basic python3 compatibility

### DIFF
--- a/Cowsay/CowsaySourceFinder.py
+++ b/Cowsay/CowsaySourceFinder.py
@@ -61,7 +61,7 @@ class CowsaySourceFinder(Processor):
         """Grabs the version from the cowsay perl file."""
 
         with open(filename, 'r') as f:
-            match = re.search('\$version = "([0-9.]+)', f.read())
+            match = re.search(r'\$version = "([0-9.]+)', f.read())
         self.env["version"] = match.group(1)
 
     def replace_text(self, filename, replacement_code, replacement):

--- a/Cowsay/CowsaySourceFinder.py
+++ b/Cowsay/CowsaySourceFinder.py
@@ -91,7 +91,7 @@ class CowsaySourceFinder(Processor):
             self.output("Set cows folder default.")
             self.output("Found %s" % self.env["cowsay_path"])
             self.output("Found version is %s" % self.env["version"])
-        except BaseException as err:
+        except Exception as err:
             raise ProcessorError(err)
 
 

--- a/Cowsay/CowsaySourceFinder.py
+++ b/Cowsay/CowsaySourceFinder.py
@@ -16,12 +16,12 @@
 
 
 from __future__ import absolute_import
+
 import glob
 import os
 import re
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["CowsaySourceFinder"]
 

--- a/Cowsay/CowsaySourceFinder.py
+++ b/Cowsay/CowsaySourceFinder.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 
+from __future__ import absolute_import
 import glob
 import os
 import re

--- a/Eclipse/OptionSelector.py
+++ b/Eclipse/OptionSelector.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """See docstring for OptionSelector class"""
 
+from __future__ import absolute_import
 import re
 import urllib2
 

--- a/Eclipse/OptionSelector.py
+++ b/Eclipse/OptionSelector.py
@@ -16,8 +16,6 @@
 """See docstring for OptionSelector class"""
 
 from __future__ import absolute_import
-import re
-import urllib2
 
 from autopkglib import Processor, ProcessorError
 

--- a/Geogebra/GeogebraURLProvider.py
+++ b/Geogebra/GeogebraURLProvider.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import urllib2
 
 from autopkglib import Processor, ProcessorError

--- a/Geogebra/GeogebraURLProvider.py
+++ b/Geogebra/GeogebraURLProvider.py
@@ -47,7 +47,7 @@ class GeogebraURLProvider(Processor):
             f = urllib2.urlopen(base_url)
             html = f.geturl()
             f.close()
-        except BaseException as err:
+        except Exception as err:
             raise ProcessorError("Can't download %s: %s" % (base_url, err))
         
         return urllib2.quote(f.geturl(), safe=":/%")

--- a/Geogebra/GeogebraURLProvider.py
+++ b/Geogebra/GeogebraURLProvider.py
@@ -15,10 +15,10 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import urllib2
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["GeogebraURLProvider"] 
 

--- a/JSSImporter/JSSImporterSourceFinder.py
+++ b/JSSImporter/JSSImporterSourceFinder.py
@@ -16,11 +16,11 @@
 
 
 from __future__ import absolute_import
-import os
+
 import glob
+import os
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["JSSImporterSourceFinder"]
 

--- a/JSSImporter/JSSImporterSourceFinder.py
+++ b/JSSImporter/JSSImporterSourceFinder.py
@@ -61,7 +61,7 @@ class JSSImporterSourceFinder(Processor):
             self.env["jssimporter_path"] = os.path.join(root_dir,
                                                               autopkg_dir)
             self.output("Found %s" % self.env["jssimporter_path"])
-        except BaseException as err:
+        except Exception as err:
             raise ProcessorError(err)
 
 

--- a/JSSImporter/JSSImporterSourceFinder.py
+++ b/JSSImporter/JSSImporterSourceFinder.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 
+from __future__ import absolute_import
 import os
 import glob
 

--- a/Jin/JinURLProvider.py
+++ b/Jin/JinURLProvider.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import re
 import urllib2
 

--- a/Jin/JinURLProvider.py
+++ b/Jin/JinURLProvider.py
@@ -15,11 +15,11 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import re
 import urllib2
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["JinURLProvider"] 
 

--- a/Jin/JinURLProvider.py
+++ b/Jin/JinURLProvider.py
@@ -50,7 +50,7 @@ class JinURLProvider(Processor):
             f = urllib2.urlopen(base_url)
             html = f.read()
             f.close()
-        except BaseException as err:
+        except Exception as err:
             raise ProcessorError("Can't download %s: %s" % (base_url, err))
         
         m = re_dmg_link.search(html)

--- a/MSOffice2011Updates/MSOffice2011DisableAllQuit.py
+++ b/MSOffice2011Updates/MSOffice2011DisableAllQuit.py
@@ -15,6 +15,7 @@
 # permissions and limitations under the License.
 """See docstring for MSOffice2011DisableAllQuit class"""
 
+from __future__ import absolute_import
 import os
 
 from autopkglib import Processor, ProcessorError

--- a/MSOffice2011Updates/MSOffice2011DisableAllQuit.py
+++ b/MSOffice2011Updates/MSOffice2011DisableAllQuit.py
@@ -16,10 +16,10 @@
 """See docstring for MSOffice2011DisableAllQuit class"""
 
 from __future__ import absolute_import
+
 import os
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["MSOffice2011DisableAllQuit"]
 

--- a/MSOffice2011Updates/MSOffice2011UpdateInfoProvider.py
+++ b/MSOffice2011Updates/MSOffice2011UpdateInfoProvider.py
@@ -211,7 +211,7 @@ class MSOffice2011UpdateInfoProvider(Processor):
             fref = urllib2.urlopen(req)
             data = fref.read()
             fref.close()
-        except BaseException as err:
+        except Exception as err:
             raise ProcessorError("Can't download %s: %s" % (base_url, err))
 
         metadata = plistlib.readPlistFromString(data)

--- a/MSOffice2011Updates/MSOffice2011UpdateInfoProvider.py
+++ b/MSOffice2011Updates/MSOffice2011UpdateInfoProvider.py
@@ -16,14 +16,13 @@
 """See docstring for MSOffice2011UpdateInfoProvider class"""
 
 from __future__ import absolute_import
+
 import plistlib
 import urllib2
-
 from distutils.version import LooseVersion
 from operator import itemgetter
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["MSOffice2011UpdateInfoProvider"]
 

--- a/MSOffice2011Updates/MSOffice2011UpdateInfoProvider.py
+++ b/MSOffice2011Updates/MSOffice2011UpdateInfoProvider.py
@@ -159,6 +159,13 @@ class MSOffice2011UpdateInfoProvider(Processor):
     def value_to_os_version_string(self, value):
         """Converts a value to an OS X version number"""
         #pylint: disable=no-self-use
+
+        # Map string type for both Python 2 and Python 3.
+        try:
+            _ = basestring
+        except NameError:
+            basestring = str  # pylint: disable=W0622
+
         if isinstance(value, int):
             version_str = hex(value)[2:]
         elif isinstance(value, basestring):

--- a/MSOffice2011Updates/MSOffice2011UpdateInfoProvider.py
+++ b/MSOffice2011Updates/MSOffice2011UpdateInfoProvider.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """See docstring for MSOffice2011UpdateInfoProvider class"""
 
+from __future__ import absolute_import
 import plistlib
 import urllib2
 

--- a/MinecraftEdu/MinecraftEduURLProvider.py
+++ b/MinecraftEdu/MinecraftEduURLProvider.py
@@ -74,7 +74,7 @@ class MinecraftEduURLProvider(Processor):
             url_handle = urllib2.urlopen(request)
             version_output = url_handle.read()
             url_handle.close()
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError("Can't open %s: %s" % (base_url, e))
         releases = filter(lambda x: dl_type in x,version_output.split("<version>"))
         version_numbers = []

--- a/MinecraftEdu/MinecraftEduURLProvider.py
+++ b/MinecraftEdu/MinecraftEduURLProvider.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from autopkglib import Processor, ProcessorError
 from distutils.version import LooseVersion
 from operator import itemgetter

--- a/MinecraftEdu/MinecraftEduURLProvider.py
+++ b/MinecraftEdu/MinecraftEduURLProvider.py
@@ -15,10 +15,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-from autopkglib import Processor, ProcessorError
+
+import urllib2
 from distutils.version import LooseVersion
 from operator import itemgetter
-import urllib2
+
+from autopkglib import Processor, ProcessorError
 
 __all__ = ["MinecraftEduURLProvider"]
 

--- a/MinecraftEdu/ParentCopier.py
+++ b/MinecraftEdu/ParentCopier.py
@@ -95,7 +95,7 @@ class ParentCopier(DmgMounter):
             else:
                 shutil.copy(source_item, dest_item)
             self.output("Copied %s to %s" % (source_item, dest_item))
-        except BaseException as err:
+        except Exception as err:
             raise ProcessorError(
                 "Can't copy %s to %s: %s" % (source_item, dest_item, err))
 

--- a/MinecraftEdu/ParentCopier.py
+++ b/MinecraftEdu/ParentCopier.py
@@ -16,13 +16,13 @@
 
 
 from __future__ import absolute_import
+
 import os.path
 import shutil
-
 from glob import glob
+
 from autopkglib import Processor, ProcessorError
 from autopkglib.DmgMounter import DmgMounter
-
 
 __all__ = ["ParentCopier"]
 

--- a/MinecraftEdu/ParentCopier.py
+++ b/MinecraftEdu/ParentCopier.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 
+from __future__ import absolute_import
 import os.path
 import shutil
 
@@ -81,7 +82,7 @@ class ParentCopier(DmgMounter):
 					shutil.rmtree(dest_item)
 				else:
 					os.unlink(dest_item)
-			except OSError, err:
+			except OSError as err:
 				raise ProcessorError(
 					"Can't remove %s: %s" % (dest_item, err.strerror))
 					
@@ -94,7 +95,7 @@ class ParentCopier(DmgMounter):
 			else:
 				shutil.copy(source_item, dest_item)
 			self.output("Copied %s to %s" % (source_item, dest_item))
-		except BaseException, err:
+		except BaseException as err:
 			raise ProcessorError(
 				"Can't copy %s to %s: %s" % (source_item, dest_item, err))
 	

--- a/MinecraftEdu/ParentCopier.py
+++ b/MinecraftEdu/ParentCopier.py
@@ -6,7 +6,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	  http://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,117 +28,116 @@ __all__ = ["ParentCopier"]
 
 
 class ParentCopier(DmgMounter):
-	description = "Copies source_path to destination_path."
-	input_variables = {
-		"source_path": {
-			"required": True,
-			"description": ("Path to a file or directory to copy. "
-				"Can point to a path inside a .dmg which will be mounted. "
-				"This path may also contain basic globbing characters such as "
-				"the wildcard '*', but only the first result will be returned."),
-		},
-		"destination_path": {
-			"required": True,
-			"description": "Path to gdestination.",
-		},
-		"overwrite": {
-			"required": False,
-			"description": "Whether the destination will be overwritten if necessary.",
-		},
-	}
-	output_variables = {
-	}
-	
-	__doc__ = description
-	
-	def find_path_for_relpath(self, relpath):
-		'''Searches for the relative path.
-		Search order is:
-			RECIPE_CACHE_DIR
-			RECIPE_DIR
-			PARENT_RECIPE directories'''
-		cache_dir = self.env.get('RECIPE_CACHE_DIR')
-		recipe_dir = self.env.get('RECIPE_DIR')
-		search_dirs = [cache_dir, recipe_dir]
-		if self.env.get("PARENT_RECIPES"):
-			# also look in the directories containing the parent recipes
-			parent_recipe_dirs = list(set([
-				os.path.dirname(item)
-				for item in self.env["PARENT_RECIPES"]]))
-			search_dirs.extend(parent_recipe_dirs)
-		for directory in search_dirs:
-			test_item = os.path.join(directory, relpath)
-			if os.path.exists(test_item):
-				return os.path.normpath(test_item)
+    description = "Copies source_path to destination_path."
+    input_variables = {
+        "source_path": {
+            "required": True,
+            "description": ("Path to a file or directory to copy. "
+                "Can point to a path inside a .dmg which will be mounted. "
+                "This path may also contain basic globbing characters such as "
+                "the wildcard '*', but only the first result will be returned."),
+        },
+        "destination_path": {
+            "required": True,
+            "description": "Path to gdestination.",
+        },
+        "overwrite": {
+            "required": False,
+            "description": "Whether the destination will be overwritten if necessary.",
+        },
+    }
+    output_variables = {
+    }
 
-		raise ProcessorError("Can't find %s" % relpath)
+    __doc__ = description
 
-	def copy(self, source_item, dest_item, overwrite=False):
-		'''Copies source_item to dest_item, overwriting if allowed'''
-		# Remove destination if needed.
-		if os.path.exists(dest_item) and overwrite:
-			try:
-				if os.path.isdir(dest_item) and not os.path.islink(dest_item):
-					shutil.rmtree(dest_item)
-				else:
-					os.unlink(dest_item)
-			except OSError as err:
-				raise ProcessorError(
-					"Can't remove %s: %s" % (dest_item, err.strerror))
-					
-		# Copy file or directory.
-		try:
-			if os.path.isdir(source_item):
-				shutil.copytree(source_item, dest_item, symlinks=True)
-			elif not os.path.isdir(dest_item):
-				shutil.copyfile(source_item, dest_item)
-			else:
-				shutil.copy(source_item, dest_item)
-			self.output("Copied %s to %s" % (source_item, dest_item))
-		except BaseException as err:
-			raise ProcessorError(
-				"Can't copy %s to %s: %s" % (source_item, dest_item, err))
-	
-	def main(self):
-		source_path = self.env['source_path']
-		# Check if we're trying to copy something inside a dmg.
-		(dmg_path, dmg,
-		 dmg_source_path) = source_path.partition(".dmg/")
-		dmg_path += ".dmg"
+    def find_path_for_relpath(self, relpath):
+        '''Searches for the relative path.
+        Search order is:
+            RECIPE_CACHE_DIR
+            RECIPE_DIR
+            PARENT_RECIPE directories'''
+        cache_dir = self.env.get('RECIPE_CACHE_DIR')
+        recipe_dir = self.env.get('RECIPE_DIR')
+        search_dirs = [cache_dir, recipe_dir]
+        if self.env.get("PARENT_RECIPES"):
+            # also look in the directories containing the parent recipes
+            parent_recipe_dirs = list(set([
+                os.path.dirname(item)
+                for item in self.env["PARENT_RECIPES"]]))
+            search_dirs.extend(parent_recipe_dirs)
+        for directory in search_dirs:
+            test_item = os.path.join(directory, relpath)
+            if os.path.exists(test_item):
+                return os.path.normpath(test_item)
 
-		# Check to see if it's a relative path and can be found inside the parent recipes
-		if source_path and not source_path.startswith("/"):
-			# search for it
-			source_path = self.find_path_for_relpath(source_path)
+        raise ProcessorError("Can't find %s" % relpath)
 
-		try:
-			if dmg:
-				# Mount dmg and copy path inside.
-				mount_point = self.mount(dmg_path)
-				source_path = os.path.join(mount_point, dmg_source_path)
-			# process path with glob.glob
-			matches = glob(source_path)
-			matched_source_path = matches[0]
-			if len(matches) > 1:
-				self.output("WARNING: Multiple paths match 'source_path' glob '%s':"
-					% source_path)
-				for match in matches:
-					self.output("  - %s" % match)
+    def copy(self, source_item, dest_item, overwrite=False):
+        '''Copies source_item to dest_item, overwriting if allowed'''
+        # Remove destination if needed.
+        if os.path.exists(dest_item) and overwrite:
+            try:
+                if os.path.isdir(dest_item) and not os.path.islink(dest_item):
+                    shutil.rmtree(dest_item)
+                else:
+                    os.unlink(dest_item)
+            except OSError as err:
+                raise ProcessorError(
+                    "Can't remove %s: %s" % (dest_item, err.strerror))
 
-			matched_source_path = glob(source_path)[0]
-			if [c for c in '*?[]!' if c in source_path]:
-				self.output("Using path '%s' matched from globbed '%s'."
-					% (matched_source_path, source_path))
+        # Copy file or directory.
+        try:
+            if os.path.isdir(source_item):
+                shutil.copytree(source_item, dest_item, symlinks=True)
+            elif not os.path.isdir(dest_item):
+                shutil.copyfile(source_item, dest_item)
+            else:
+                shutil.copy(source_item, dest_item)
+            self.output("Copied %s to %s" % (source_item, dest_item))
+        except BaseException as err:
+            raise ProcessorError(
+                "Can't copy %s to %s: %s" % (source_item, dest_item, err))
 
-			# do the copy
-			self.copy(matched_source_path, self.env['destination_path'],
-					  overwrite=self.env.get("overwrite"))
-		finally:
-			if dmg:
-				self.unmount(dmg_path)
-	
+    def main(self):
+        source_path = self.env['source_path']
+        # Check if we're trying to copy something inside a dmg.
+        (dmg_path, dmg,
+         dmg_source_path) = source_path.partition(".dmg/")
+        dmg_path += ".dmg"
+
+        # Check to see if it's a relative path and can be found inside the parent recipes
+        if source_path and not source_path.startswith("/"):
+            # search for it
+            source_path = self.find_path_for_relpath(source_path)
+
+        try:
+            if dmg:
+                # Mount dmg and copy path inside.
+                mount_point = self.mount(dmg_path)
+                source_path = os.path.join(mount_point, dmg_source_path)
+            # process path with glob.glob
+            matches = glob(source_path)
+            matched_source_path = matches[0]
+            if len(matches) > 1:
+                self.output("WARNING: Multiple paths match 'source_path' glob '%s':"
+                    % source_path)
+                for match in matches:
+                    self.output("  - %s" % match)
+
+            matched_source_path = glob(source_path)[0]
+            if [c for c in '*?[]!' if c in source_path]:
+                self.output("Using path '%s' matched from globbed '%s'."
+                    % (matched_source_path, source_path))
+
+            # do the copy
+            self.copy(matched_source_path, self.env['destination_path'],
+                      overwrite=self.env.get("overwrite"))
+        finally:
+            if dmg:
+                self.unmount(dmg_path)
+
 
 if __name__ == '__main__':
-	processor = ParentCopier()
-	processor.execute_shell()
-	
+    processor = ParentCopier()
+    processor.execute_shell()

--- a/MinecraftEdu/ParentUnarchiver.py
+++ b/MinecraftEdu/ParentUnarchiver.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 
+from __future__ import absolute_import
 import os
 import subprocess
 import shutil

--- a/MinecraftEdu/ParentUnarchiver.py
+++ b/MinecraftEdu/ParentUnarchiver.py
@@ -110,7 +110,7 @@ class ParentUnarchiver(Processor):
             try:
                 os.mkdir(destination_path)
             except OSError as e:
-                raise ProcessorError("Can't create %s: %s" % (path, e.strerror))
+                raise ProcessorError("Can't create %s: %s" % (destination_path, e.strerror))
         elif self.env.get('purge_destination'):
             for entry in os.listdir(destination_path):
                 path = os.path.join(destination_path, entry)

--- a/MinecraftEdu/ParentUnarchiver.py
+++ b/MinecraftEdu/ParentUnarchiver.py
@@ -26,150 +26,149 @@ from autopkglib import Processor, ProcessorError
 __all__ = ["ParentUnarchiver"]
 
 EXTNS = {
-	'zip': ['zip'],
-	'tar_gzip': ['tar.gz', 'tgz'],
-	'tar_bzip2': ['tar.bz2', 'tbz'],
-	'tar': ['tar']
+    'zip': ['zip'],
+    'tar_gzip': ['tar.gz', 'tgz'],
+    'tar_bzip2': ['tar.bz2', 'tbz'],
+    'tar': ['tar']
 }
 
 class ParentUnarchiver(Processor):
-	description = "Archive decompressor for zip and common tar-compressed formats. Also searches parent recipes if relative path is given."
-	input_variables = {
-		"archive_path": {
-			"required": False,
-			"description": "Path to an archive. Defaults to contents of the 'pathname' "
-						   "variable, for example as is set by URLDownloader.",
-		},
-		"destination_path": {
-			"required": False,
-			"description": ("Directory where archive will be unpacked, created if necessary. "
-						   "Defaults to RECIPE_CACHE_DIR/NAME.")
-		},
-		"purge_destination": {
-			"required": False,
-			"description": "Whether the contents of the destination directory will be removed before unpacking.",
-		},
-		"archive_format": {
-			"required": False,
-			"description": ("The archive format. Currently supported: 'zip', 'tar_gzip', 'tar_bzip2'. "
-						   "If omitted, the format will try to be guessed by the file extension.")
-		}
-	}
-	output_variables = {
-	}
-	
-	__doc__ = description
+    description = "Archive decompressor for zip and common tar-compressed formats. Also searches parent recipes if relative path is given."
+    input_variables = {
+        "archive_path": {
+            "required": False,
+            "description": "Path to an archive. Defaults to contents of the 'pathname' "
+                           "variable, for example as is set by URLDownloader.",
+        },
+        "destination_path": {
+            "required": False,
+            "description": ("Directory where archive will be unpacked, created if necessary. "
+                           "Defaults to RECIPE_CACHE_DIR/NAME.")
+        },
+        "purge_destination": {
+            "required": False,
+            "description": "Whether the contents of the destination directory will be removed before unpacking.",
+        },
+        "archive_format": {
+            "required": False,
+            "description": ("The archive format. Currently supported: 'zip', 'tar_gzip', 'tar_bzip2'. "
+                           "If omitted, the format will try to be guessed by the file extension.")
+        }
+    }
+    output_variables = {
+    }
 
-	def find_path_for_relpath(self, relpath):
-		'''Searches for the relative path.
-		Search order is:
-			RECIPE_CACHE_DIR
-			RECIPE_DIR
-			PARENT_RECIPE directories'''
-		cache_dir = self.env.get('RECIPE_CACHE_DIR')
-		recipe_dir = self.env.get('RECIPE_DIR')
-		search_dirs = [cache_dir, recipe_dir]
-		if self.env.get("PARENT_RECIPES"):
-			# also look in the directories containing the parent recipes
-			parent_recipe_dirs = list(set([
-				os.path.dirname(item)
-				for item in self.env["PARENT_RECIPES"]]))
-			search_dirs.extend(parent_recipe_dirs)
-		for directory in search_dirs:
-			test_item = os.path.join(directory, relpath)
-			if os.path.exists(test_item):
-				return os.path.normpath(test_item)
+    __doc__ = description
 
-		raise ProcessorError("Can't find %s" % relpath)
-			
-	def get_archive_format(self, archive_path):
-		for format, extns in EXTNS.items():
-			for extn in extns:
-				if archive_path.endswith(extn):
-					return format
-		# We found no known archive file extension if we got this far
-		return None
+    def find_path_for_relpath(self, relpath):
+        '''Searches for the relative path.
+        Search order is:
+            RECIPE_CACHE_DIR
+            RECIPE_DIR
+            PARENT_RECIPE directories'''
+        cache_dir = self.env.get('RECIPE_CACHE_DIR')
+        recipe_dir = self.env.get('RECIPE_DIR')
+        search_dirs = [cache_dir, recipe_dir]
+        if self.env.get("PARENT_RECIPES"):
+            # also look in the directories containing the parent recipes
+            parent_recipe_dirs = list(set([
+                os.path.dirname(item)
+                for item in self.env["PARENT_RECIPES"]]))
+            search_dirs.extend(parent_recipe_dirs)
+        for directory in search_dirs:
+            test_item = os.path.join(directory, relpath)
+            if os.path.exists(test_item):
+                return os.path.normpath(test_item)
 
-	def main(self):
-		# handle some defaults for archive_path and destination_path
-		archive_path = self.env.get("archive_path", self.env.get("pathname"))
-		if not archive_path:
-			raise ProcessorError("Expected an 'archive_path' input variable but none is set!")
-			
-		# convert relative path into absolute path by stealing code from PkgCreator
-		if archive_path and not archive_path.startswith("/"):
-					# search for it
-					archive_path = self.find_path_for_relpath(archive_path)
-		
-		
-		destination_path = self.env.get("destination_path",
-					os.path.join(self.env["RECIPE_CACHE_DIR"], self.env["NAME"]))
+        raise ProcessorError("Can't find %s" % relpath)
 
-		# Create the directory if needed.
-		if not os.path.exists(destination_path):
-			try:
-				os.mkdir(destination_path)
-			except OSError as e:
-				raise ProcessorError("Can't create %s: %s" % (path, e.strerror))
-		elif self.env.get('purge_destination'):
-			for entry in os.listdir(destination_path):
-				path = os.path.join(destination_path, entry)
-				try:
-					if os.path.isdir(path) and not os.path.islink(path):
-						shutil.rmtree(path)
-					else:
-						os.unlink(path)
-				except OSError as e:
-					raise ProcessorError("Can't remove %s: %s" % (path, e.strerror))
-		
-		fmt = self.env.get("archive_format")
-		if fmt is None:
-			fmt = self.get_archive_format(archive_path)
-			if not fmt:
-				raise ProcessorError("Can't guess archive format for filename %s" %
-						os.path.basename(archive_path))
-			self.output("Guessed archive format '%s' from filename %s" %
-						(fmt, os.path.basename(archive_path)))
-		elif fmt not in EXTNS.keys():
-			raise ProcessorError("'%s' is not valid for the 'archive_format' variable. Must be one of %s." %
-								(fmt, ", ".join(EXTNS.keys())))
+    def get_archive_format(self, archive_path):
+        for format, extns in EXTNS.items():
+            for extn in extns:
+                if archive_path.endswith(extn):
+                    return format
+        # We found no known archive file extension if we got this far
+        return None
 
-		if fmt == "zip":
-			cmd = ["/usr/bin/ditto",
-				   "--noqtn",
-				   "-x",
-				   "-k",
-				   archive_path,
-				   destination_path]
-		elif fmt.startswith("tar"):
-			cmd = ["/usr/bin/tar",
-				   "-x",
-				   "-f",
-				   archive_path,
-				   "-C",
-				   destination_path]
-			if fmt.endswith("gzip"):
-				cmd.append("-z")
-			elif fmt.endswith("bzip2"):
-				cmd.append("-j")
+    def main(self):
+        # handle some defaults for archive_path and destination_path
+        archive_path = self.env.get("archive_path", self.env.get("pathname"))
+        if not archive_path:
+            raise ProcessorError("Expected an 'archive_path' input variable but none is set!")
 
-		# Call command.
-		try:
-			p = subprocess.Popen(cmd,
-								 stdout=subprocess.PIPE,
-								 stderr=subprocess.PIPE)
-			(out, err) = p.communicate()
-		except OSError as e:
-			raise ProcessorError("%s execution failed with error code %d: %s" % (
-								  os.path.basename(cmd[0]), e.errno, e.strerror))
-		if p.returncode != 0:
-			raise ProcessorError("Unarchiving %s with %s failed: %s" % (
-								  archive_path, os.path.basename(cmd[0]), err))
-		
-		self.output("Unarchived %s to %s" 
-					% (archive_path, destination_path))
+        # convert relative path into absolute path by stealing code from PkgCreator
+        if archive_path and not archive_path.startswith("/"):
+                    # search for it
+                    archive_path = self.find_path_for_relpath(archive_path)
+
+
+        destination_path = self.env.get("destination_path",
+                    os.path.join(self.env["RECIPE_CACHE_DIR"], self.env["NAME"]))
+
+        # Create the directory if needed.
+        if not os.path.exists(destination_path):
+            try:
+                os.mkdir(destination_path)
+            except OSError as e:
+                raise ProcessorError("Can't create %s: %s" % (path, e.strerror))
+        elif self.env.get('purge_destination'):
+            for entry in os.listdir(destination_path):
+                path = os.path.join(destination_path, entry)
+                try:
+                    if os.path.isdir(path) and not os.path.islink(path):
+                        shutil.rmtree(path)
+                    else:
+                        os.unlink(path)
+                except OSError as e:
+                    raise ProcessorError("Can't remove %s: %s" % (path, e.strerror))
+
+        fmt = self.env.get("archive_format")
+        if fmt is None:
+            fmt = self.get_archive_format(archive_path)
+            if not fmt:
+                raise ProcessorError("Can't guess archive format for filename %s" %
+                        os.path.basename(archive_path))
+            self.output("Guessed archive format '%s' from filename %s" %
+                        (fmt, os.path.basename(archive_path)))
+        elif fmt not in EXTNS.keys():
+            raise ProcessorError("'%s' is not valid for the 'archive_format' variable. Must be one of %s." %
+                                (fmt, ", ".join(EXTNS.keys())))
+
+        if fmt == "zip":
+            cmd = ["/usr/bin/ditto",
+                   "--noqtn",
+                   "-x",
+                   "-k",
+                   archive_path,
+                   destination_path]
+        elif fmt.startswith("tar"):
+            cmd = ["/usr/bin/tar",
+                   "-x",
+                   "-f",
+                   archive_path,
+                   "-C",
+                   destination_path]
+            if fmt.endswith("gzip"):
+                cmd.append("-z")
+            elif fmt.endswith("bzip2"):
+                cmd.append("-j")
+
+        # Call command.
+        try:
+            p = subprocess.Popen(cmd,
+                                 stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE)
+            (out, err) = p.communicate()
+        except OSError as e:
+            raise ProcessorError("%s execution failed with error code %d: %s" % (
+                                  os.path.basename(cmd[0]), e.errno, e.strerror))
+        if p.returncode != 0:
+            raise ProcessorError("Unarchiving %s with %s failed: %s" % (
+                                  archive_path, os.path.basename(cmd[0]), err))
+
+        self.output("Unarchived %s to %s"
+                    % (archive_path, destination_path))
 
 if __name__ == '__main__':
-	processor = ParentUnarchiver()
-	processor.execute_shell()
-	
+    processor = ParentUnarchiver()
+    processor.execute_shell()

--- a/MinecraftEdu/ParentUnarchiver.py
+++ b/MinecraftEdu/ParentUnarchiver.py
@@ -16,12 +16,12 @@
 
 
 from __future__ import absolute_import
+
 import os
-import subprocess
 import shutil
+import subprocess
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["ParentUnarchiver"]
 

--- a/MinecraftEdu/ParentUnarchiver.py
+++ b/MinecraftEdu/ParentUnarchiver.py
@@ -130,9 +130,9 @@ class ParentUnarchiver(Processor):
                         os.path.basename(archive_path))
             self.output("Guessed archive format '%s' from filename %s" %
                         (fmt, os.path.basename(archive_path)))
-        elif fmt not in EXTNS.keys():
+        elif fmt not in EXTNS:
             raise ProcessorError("'%s' is not valid for the 'archive_format' variable. Must be one of %s." %
-                                (fmt, ", ".join(EXTNS.keys())))
+                                (fmt, ", ".join(EXTNS)))
 
         if fmt == "zip":
             cmd = ["/usr/bin/ditto",

--- a/MinecraftEdu/ParentUnarchiver.py
+++ b/MinecraftEdu/ParentUnarchiver.py
@@ -6,7 +6,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	  http://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/MinecraftEdu/TextReplacer.py
+++ b/MinecraftEdu/TextReplacer.py
@@ -16,8 +16,8 @@
 
 
 from __future__ import absolute_import
-from autopkglib import Processor, ProcessorError
 
+from autopkglib import Processor, ProcessorError
 
 __all__ = ["TextReplacer"]
 

--- a/MinecraftEdu/TextReplacer.py
+++ b/MinecraftEdu/TextReplacer.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 
+from __future__ import absolute_import
 from autopkglib import Processor, ProcessorError
 
 

--- a/MinecraftEdu/TextReplacer.py
+++ b/MinecraftEdu/TextReplacer.py
@@ -6,7 +6,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	  http://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -58,5 +58,5 @@ class TextReplacer(Processor):
 
 
 if __name__ == '__main__':
-	processor = TextReplacer()
-	processor.execute_shell()
+    processor = TextReplacer()
+    processor.execute_shell()

--- a/NetHack/NetHackVersioner.py
+++ b/NetHack/NetHackVersioner.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 
+from __future__ import absolute_import
 import re
 
 from autopkglib import Processor, ProcessorError

--- a/NetHack/NetHackVersioner.py
+++ b/NetHack/NetHackVersioner.py
@@ -52,7 +52,7 @@ class NetHackVersioner(Processor):
         else:
             self.env["version"] = "0.0.0"
             self.output("No version found!")
-        # except BaseException as err:
+        # except Exception as err:
         #     raise ProcessorError(err)
 
 

--- a/NetHack/NetHackVersioner.py
+++ b/NetHack/NetHackVersioner.py
@@ -44,7 +44,7 @@ class NetHackVersioner(Processor):
         with open(self.env["input_path"], "rb") as nethack:
             nethack_data = nethack.read()
 
-        regex = re.compile("MacOSX NetHack Version ([\d+\.]{3,})")
+        regex = re.compile(r"MacOSX NetHack Version ([\d+\.]{3,})")
         found = re.search(regex, nethack_data)
         if found:
             self.env["version"] = found.group(1)

--- a/NetHack/NetHackVersioner.py
+++ b/NetHack/NetHackVersioner.py
@@ -16,10 +16,10 @@
 
 
 from __future__ import absolute_import
+
 import re
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["NetHackVersioner"]
 


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later (including `urllib2.quote`), but this should catch the low-hanging fruit right now.