### PR TITLE
Update & fix AirServer.download.recipe

### DIFF
--- a/AirServer/AirServer.download.recipe
+++ b/AirServer/AirServer.download.recipe
@@ -26,8 +26,6 @@
                 <string>%DOWNLOAD_URL%</string>
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
-                <key>url</key>
-                <string>https://www.airserver.com/download/mac/latest</string>
             </dict>
         </dict>
         <dict>

--- a/AirServer/AirServer.download.recipe
+++ b/AirServer/AirServer.download.recipe
@@ -10,28 +10,11 @@
     <dict>
         <key>NAME</key>
         <string>AirServer</string>
-        <key>BASEURL</key>
-        <string>https://www.airserver.com/Download/MacPC</string>
-        <key>RE_PATTERN</key>
-        <string>(http.*airserver.*dmg)</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.9</string>
     <key>Process</key>
     <array>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>%BASEURL%</string>
-                <key>re_pattern</key>
-                <string>%RE_PATTERN%</string>
-                <key>result_output_var_name</key>
-                <string>url</string>
-            </dict>
-            <key>Processor</key>
-            <string>URLTextSearcher</string>
-        </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>
@@ -39,11 +22,24 @@
             <dict>
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
+                <key>url</key>
+                <string>https://www.airserver.com/download/mac/latest</string>
             </dict>
         </dict>
         <dict>
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/AirServer.app</string>
+                <key>requirements</key>
+                <string>anchor apple generic and certificate leaf[subject.OU] = "6C755KS5W3"</string>
+            </dict>
         </dict>
     </array>
 </dict>


### PR DESCRIPTION
- Remove BASEURL & RE_PATTERN input vars, since Mac download is accessible from single URL
- Hardcode download url in URLDownloader
- Add CodeSignatureVerifier to check app code signature

Resulting verbose output from successful download recipe run:
```xml
adminMac:~ admin$ autopkg run ~/Documents/GitHub/sheagcraig-recipes/AirServer/AirServer.download.recipe -vv
Processing /Users/admin/Documents/GitHub/sheagcraig-recipes/AirServer/AirServer.download.recipe...
WARNING: /Users/admin/Documents/GitHub/sheagcraig-recipes/AirServer/AirServer.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': u'AirServer.dmg',
           'url': u'https://www.airserver.com/download/mac/latest'}}
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 20 Apr 2020 20:26:39 GMT
URLDownloader: Storing new ETag header: 0x8D7E569217D4444
URLDownloader: Downloaded /Users/admin/Library/AutoPkg/Cache/com.github.sheagcraig.download.AirServer/downloads/AirServer.dmg
{'Output': {'download_changed': True,
            'etag': '0x8D7E569217D4444',
            'last_modified': 'Mon, 20 Apr 2020 20:26:39 GMT',
            'pathname': u'/Users/admin/Library/AutoPkg/Cache/com.github.sheagcraig.download.AirServer/downloads/AirServer.dmg',
            'url_downloader_summary_result': {'data': {'download_path': u'/Users/admin/Library/AutoPkg/Cache/com.github.sheagcraig.download.AirServer/downloads/AirServer.dmg'},
                                              'summary_text': 'The following new items were downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': u'/Users/admin/Library/AutoPkg/Cache/com.github.sheagcraig.download.AirServer/downloads/AirServer.dmg/AirServer.app'}}
CodeSignatureVerifier: Mounted disk image /Users/admin/Library/AutoPkg/Cache/com.github.sheagcraig.download.AirServer/downloads/AirServer.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.vb4TLx/AirServer.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.vb4TLx/AirServer.app: satisfies its Designated Requirement
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to /Users/admin/Library/AutoPkg/Cache/com.github.sheagcraig.download.AirServer/receipts/AirServer.download-receipt-20200505-155156.plist

The following new items were downloaded:
    Download Path                                                                                              
    -------------                                                                                              
    /Users/admin/Library/AutoPkg/Cache/com.github.sheagcraig.download.AirServer/downloads/AirServer.dmg  
```