### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/AdobeDNGCoverter/AdobeDNGConverter.download.recipe
+++ b/AdobeDNGCoverter/AdobeDNGConverter.download.recipe
@@ -21,7 +21,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://www.adobe.com/go/dng_converter_mac/</string>
+                <string>https://www.adobe.com/go/dng_converter_mac/</string>
                 <key>re_pattern</key>
                 <string>(?P&lt;part1&gt;thankyou.jsp\?ftpID=[0-9]+?)&amp;amp;(?P&lt;part2&gt;fileID=[0-9]+)</string>
                 <!-- Example: 

--- a/Greenfoot/Greenfoot.download.recipe
+++ b/Greenfoot/Greenfoot.download.recipe
@@ -21,9 +21,9 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://www.greenfoot.org/download</string>
+                <string>https://www.greenfoot.org/download</string>
                 <key>re_pattern</key>
-                <string>http://www.greenfoot.org/download/files/Greenfoot-mac-[\S]+.zip</string>
+                <string>https://www.greenfoot.org/download/files/Greenfoot-mac-[\S]+.zip</string>
             </dict>
         </dict>
         <dict>

--- a/Jin/Jin.download.recipe
+++ b/Jin/Jin.download.recipe
@@ -23,7 +23,7 @@
                 <key>re_pattern</key>
                 <string>href="(?P&lt;url&gt;http://sourceforge\.net/projects/jin/files/jin/jin-(?P&lt;version&gt;[\d\.]+)/jin-[\d\.]+-macosx-lion.dmg/download)"</string>
                 <key>url</key>
-                <string>http://www.jinchess.com/osx_download</string>
+                <string>https://www.jinchess.com/osx_download</string>
             </dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>


### PR DESCRIPTION
Detected and changed HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure download success.

Includes some changes redundant with #59 and #60, so merge those first if you intend to.