### PR TITLE
Deprecate recipes that have been copied to homebysix-recipes

### DIFF
--- a/AirServer/AirServer.download.recipe
+++ b/AirServer/AirServer.download.recipe
@@ -19,6 +19,22 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>The sheagcraig-recipes repository is deprecated.
+Details: https://github.com/autopkg/sheagcraig-recipes/issues/71
+
+Copies of these recipes have been created in the homebysix-recipes repo:
+- AirServer.download
+- AirServer.install
+- AirServer.pkg
+                </string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>

--- a/Eclipse/Eclipse.download.recipe
+++ b/Eclipse/Eclipse.download.recipe
@@ -19,6 +19,23 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>The sheagcraig-recipes repository is deprecated.
+Details: https://github.com/autopkg/sheagcraig-recipes/issues/71
+
+Copies of these recipes have been created in the homebysix-recipes repo:
+- Eclipse.download
+- Eclipse.install
+- Eclipse.munki
+- Eclipse.pkg
+                </string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>OptionSelector</string>
             <key>Arguments</key>
             <dict>

--- a/EclipseLuna/EclipseLuna.download.recipe
+++ b/EclipseLuna/EclipseLuna.download.recipe
@@ -19,6 +19,21 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>The sheagcraig-recipes repository is deprecated.
+Details: https://github.com/autopkg/sheagcraig-recipes/issues/71
+
+Copies of these recipes have been created in the homebysix-recipes repo:
+- EclipseLuna.download
+- EclipseLuna.pkg
+                </string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>

--- a/GeometersSketchpad5/GSP5.download.recipe
+++ b/GeometersSketchpad5/GSP5.download.recipe
@@ -17,6 +17,21 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>The sheagcraig-recipes repository is deprecated.
+Details: https://github.com/autopkg/sheagcraig-recipes/issues/71
+
+Copies of these recipes have been created in the homebysix-recipes repo:
+- GSP5.download
+- GSP5.pkg
+                </string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>

--- a/Jin/Jin.download.recipe
+++ b/Jin/Jin.download.recipe
@@ -18,6 +18,21 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>The sheagcraig-recipes repository is deprecated.
+Details: https://github.com/autopkg/sheagcraig-recipes/issues/71
+
+Copies of these recipes have been created in the homebysix-recipes repo:
+- Jin.download
+- Jin.pkg
+                </string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>

--- a/MMD-QuickLook/MMD-QuickLook.download.recipe
+++ b/MMD-QuickLook/MMD-QuickLook.download.recipe
@@ -20,6 +20,22 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>The sheagcraig-recipes repository is deprecated.
+Details: https://github.com/autopkg/sheagcraig-recipes/issues/71
+
+Copies of these recipes have been created in the homebysix-recipes repo:
+- MMD-QuickLook.download
+- MMD-QuickLook.install
+- MMD-QuickLook.munki
+				</string>
+			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>github_repo</key>

--- a/OpenEmu/OpenEmu.download.recipe
+++ b/OpenEmu/OpenEmu.download.recipe
@@ -2,21 +2,36 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>Description</key>
-    <string>Downloads the current release version of OpenEmu.</string>
-    <key>Identifier</key>
-    <string>com.github.sheagcraig.download.OpenEmu</string>
-    <key>Input</key>
-    <dict>
-        <key>NAME</key>
-        <string>OpenEmu</string>
+	<key>Description</key>
+	<string>Downloads the current release version of OpenEmu.</string>
+	<key>Identifier</key>
+	<string>com.github.sheagcraig.download.OpenEmu</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>OpenEmu</string>
 		<key>SPARKLE_FEED_URL</key>
 		<string>https://raw.github.com/OpenEmu/OpenEmu-Update/master/appcast.xml</string>
-    </dict>
-    <key>MinimumVersion</key>
-    <string>0.4.0</string>
-    <key>Process</key>
-    <array>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.4.0</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>The sheagcraig-recipes repository is deprecated.
+Details: https://github.com/autopkg/sheagcraig-recipes/issues/71
+
+Copies of these recipes have been created in the homebysix-recipes repo:
+- OpenEmu.download
+- OpenEmu.pkg
+				</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/VirtualBox/VirtualBox.download.recipe
+++ b/VirtualBox/VirtualBox.download.recipe
@@ -17,6 +17,21 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>The sheagcraig-recipes repository is deprecated.
+Details: https://github.com/autopkg/sheagcraig-recipes/issues/71
+
+Copies of these recipes have been created in the homebysix-recipes repo:
+- VirtualBox.download
+- VirtualBox.pkg
+                </string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLTextSearcher</string>
             <key>Arguments</key>
             <dict>

--- a/jss_helper/jss_helper.download.recipe
+++ b/jss_helper/jss_helper.download.recipe
@@ -17,6 +17,20 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>The sheagcraig-recipes repository is deprecated.
+Details: https://github.com/autopkg/sheagcraig-recipes/issues/71
+
+Copies of these recipes have been created in the homebysix-recipes repo:
+- jss_helper.download
+                </string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>GitHubReleasesInfoProvider</string>
             <key>Comment</key>
             <string>Get the latest release package.</string>

--- a/yo/yo.download.recipe
+++ b/yo/yo.download.recipe
@@ -17,6 +17,20 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>The sheagcraig-recipes repository is deprecated.
+Details: https://github.com/autopkg/sheagcraig-recipes/issues/71
+
+Copies of these recipes have been created in the homebysix-recipes repo:
+- yo.download
+                </string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>GitHubReleasesInfoProvider</string>
             <key>Comment</key>
             <string>Get the latest release package.</string>


### PR DESCRIPTION
These recipes have been [copied](https://github.com/autopkg/homebysix-recipes/pull/414) to the homebysix-recipes repo, per https://github.com/autopkg/sheagcraig-recipes/issues/71.

Overrides and child recipes should be updated to use the new homebysix-recipes version of these items.